### PR TITLE
add filter for thumbnail image link URLs

### DIFF
--- a/includes/taxonomy-images/public-filters.php
+++ b/includes/taxonomy-images/public-filters.php
@@ -274,7 +274,7 @@ function sermon_images_plugin_list_the_terms( $default, $args ) {
 		}
 		$image = wp_get_attachment_image( $term->image_id, $args['image_size'] );
 		if ( ! empty( $image ) ) {
-			$output .= $args['before_image'] . '<a href="' . esc_url( get_term_link( $term, $term->taxonomy ) ) . '">' . $image .'</a>' . $args['after_image'];
+			$output .= $args['before_image'] . '<a href="' . esc_url( apply_filters( 'sermon-images-list-the-terms-link-url', get_term_link( $term, $term->taxonomy ) ) ) . '">' . $image .'</a>' . $args['after_image'];
 		}
 	}
 


### PR DESCRIPTION
Allows theme authors to override the link so they can make the thumbnail link to the individual sermon rather than the series.

For example, on http://ebckingsmountain.com/resources/sermons/, I would expect the image link to be the same as the sermon title, giving me a bigger target to click on to get to the individual sermons.