### PR TITLE
Fix Shortcode Pagination on Static Front Page

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -591,6 +591,8 @@ class WPFC_Shortcodes {
 		// set page
 		if ( get_query_var( 'paged' ) ) {
 			$my_page = get_query_var( 'paged' );
+		} elseif ( get_query_var( 'page' ) ) { 
+			$my_page = get_query_var( 'page' ); 
 		} else {
 			global $paged;
 			$paged = $my_page = 1;


### PR DESCRIPTION
In accordance with the recommendation of the Wordpress Documentation (https://codex.wordpress.org/Pagination) this change allows pagination to work on the static front page.

This pull request has been created as you requested here https://wordpress.org/support/topic/shortcode-pagination-broken-on-front-page/