### PR TITLE
tweak duration instructions

### DIFF
--- a/includes/types-taxonomies.php
+++ b/includes/types-taxonomies.php
@@ -320,7 +320,7 @@ function wpfc_sermon_metaboxes() {
 	) );
 	$cmb2->add_field( array(
 		'name' => __( 'MP3 Duration', 'sermon-manager' ),
-		'desc' => __( 'Length in minutes (if left blank, will attempt to calculate automatically when you save)', 'sermon-manager' ),
+		'desc' => __( 'Length in <code>hh:mm:ss</code> format (if left blank, will attempt to calculate automatically when you save)', 'sermon-manager' ),
 		'id'   => '_wpfc_sermon_duration',
 		'type' => 'text',
 	) );


### PR DESCRIPTION
If these instructions are followed, they avoid an issue where podcast clients would take “45” to mean 45 seconds rather than a round 45 minutes.