### PR TITLE
Fix to issue #37 of localized RFC5322 time stamps.

### DIFF
--- a/includes/podcast-functions.php
+++ b/includes/podcast-functions.php
@@ -22,7 +22,6 @@ add_action( 'do_feed_podcast', 'wpfc_podcast_render', 10, 1 );
 function wpfc_podcast_add_hooks( $query ) {
 	if ( ! is_admin() && $query->is_main_query() && $query->is_feed() ) {
 		if ( is_post_type_archive( 'wpfc_sermon' ) || is_tax( 'wpfc_preacher' ) || is_tax( 'wpfc_sermon_topics' ) || is_tax( 'wpfc_service_type' ) || is_tax( 'wpfc_sermon_series' ) || is_tax( 'wpfc_bible_book' ) ) {
-			add_filter( 'get_post_time', 'wpfc_podcast_item_date', 10, 3 );
 			add_filter( 'bloginfo_rss', 'wpfc_bloginfo_rss_filter', 10, 2 );
 			add_filter( 'wp_title_rss', 'wpfc_modify_podcast_title', 99, 3 );
 			add_action( 'rss_ns', 'wpfc_podcast_add_namespace' );
@@ -182,20 +181,6 @@ function wpfc_podcast_summary( $content ) {
 	}
 
 	return $content;
-}
-
-/**
- * Replace feed item published date with Sermon date
- *
- * @param string $time The formatted time.
- * @param string $d    Format to use for retrieving the time the post was written.
- *                     Accepts 'G', 'U', or php date format. Default 'U'.
- * @param bool   $gmt  Whether to retrieve the GMT time. Default false.
- *
- * @return string Modified date
- */
-function wpfc_podcast_item_date( $time, $d = 'U', $gmt = false ) {
-	return wpfc_sermon_date( 'D, d M Y H:i:s O' );
 }
 
 /**


### PR DESCRIPTION
Fixes issue #37 of localized RFC5322 time stamps.

Since sermon dates are no longer tracked but have been obsoleted by post time stamps the custom [`get_post_time` hook](https://developer.wordpress.org/reference/hooks/get_post_time) has become redundant. This hook also echoed localized *sort of RFC5322* time stamps instead of returning a MySQL time stamp string for the [`mysql2date()`](https://developer.wordpress.org/reference/functions/mysql2date) function which caused all the trouble of issue #37. Yet, this fix is not perfect because according to [RFC5322 time stamps *should* express local time](https://tools.ietf.org/html/rfc5322#section-3.3) with a timezone offset, but it restores correct functionality for every locale and timezone. In order to fully comply with RFC5322 changes need to be made to WordPress&#x2019;s [`wp-includes/rss2-feed.php`](https://github.com/WordPress/WordPress/blob/800ad7bd0498f98788bdc1e0f50af2f36343d87a/wp-includes/feed-rss2.php#L92) file.