### PR TITLE
Minor fix to wpfc_podcast_item_date()

### DIFF
--- a/includes/podcast-functions.php
+++ b/includes/podcast-functions.php
@@ -195,7 +195,7 @@ function wpfc_podcast_summary( $content ) {
  * @return string Modified date
  */
 function wpfc_podcast_item_date( $time, $d = 'U', $gmt = false ) {
-	return sm_get_the_date( 'D, d M Y H:i:s O' );
+	return sm_get_the_date( $d );
 }
 
 /**


### PR DESCRIPTION
In this context we do not want to change the date and time format returned by a call to `get_post_time()` but the time stamp value itself. In other words, we do not filter for the format but for the value of the time stamp. So, in a call to `sm_get_the_date()` the expected date and time format should actually just be passed unaltered.