### PR TITLE
Change spelling of the book from Psalm to Psalms

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -135,7 +135,7 @@ class WPFC_Shortcodes {
 					'Nehemiah',
 					'Esther',
 					'Job',
-					'Psalm',
+					'Psalms',
 					'Proverbs',
 					'Ecclesiastes',
 					'Song of Songs',

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -605,7 +605,7 @@ function wpfc_get_term_dropdown( $taxonomy, $default = '' ) {
 			'Nehemiah',
 			'Esther',
 			'Job',
-			'Psalm',
+			'Psalms',
 			'Proverbs',
 			'Ecclesiastes',
 			'Song of Songs',


### PR DESCRIPTION
Having the book spelled as `"Psalm"` causes the ordering to be inaccurate.