### PR TITLE
Add optional display of attachments on archive page

### DIFF
--- a/includes/admin/settings/class-sm-settings-general.php
+++ b/includes/admin/settings/class-sm-settings-general.php
@@ -77,6 +77,13 @@ class SM_Settings_General extends SM_Settings_Page {
 				'default' => 'no',
 			),
 			array(
+				'title'   => __( 'Display attachments on archive pages', 'sermon-manager-for-wordpress' ),
+				'type'    => 'checkbox',
+				'desc'    => __( 'Display attachments on archive pages', 'sermon-manager-for-wordpress' ),
+				'id'      => 'archive_meta',
+				'default' => 'no',
+			),
+			array(
 				'title'   => __( 'Audio & Video Player', 'sermon-manager-for-wordpress' ),
 				'type'    => 'select',
 				'desc'    => __( 'Select which player to use for playing Sermons', 'sermon-manager-for-wordpress' ),

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -530,12 +530,14 @@ function wpfc_sermon_excerpt( $return = false ) {
 				<?php the_terms( $post->ID, 'wpfc_sermon_series', '<span class="sermon_series">' . __( 'Series: ', 'sermon-manager-for-wordpress' ), ' ', '</span>' ); ?>
             </p>
         </div>
-		<?php if ( \SermonManager::getOption( 'archive_player' ) ): ?>
+		<?php if ( \SermonManager::getOption( 'archive_player' ) || \SermonManager::getOption( 'archive_meta' ) ): ?>
             <div class="wpfc_sermon cf">
+			<?php if ( \SermonManager::getOption( 'archive_player' ) ): ?>
 				<?php echo wpfc_sermon_media(); ?>
-				<?php if ( \SermonManager::getOption( 'archive_meta' ) ): ?>
-					<?php echo wpfc_sermon_attachments(); ?>
-				<?php endif; ?>
+			<?php endif; ?>
+			<?php if ( \SermonManager::getOption( 'archive_meta' ) ): ?>
+				<?php echo wpfc_sermon_attachments(); ?>
+			<?php endif; ?>
             </div>
 		<?php endif; ?>
     </div>

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -533,6 +533,9 @@ function wpfc_sermon_excerpt( $return = false ) {
 		<?php if ( \SermonManager::getOption( 'archive_player' ) ): ?>
             <div class="wpfc_sermon cf">
 				<?php echo wpfc_sermon_media(); ?>
+				<?php if ( \SermonManager::getOption( 'archive_meta' ) ): ?>
+					<?php echo wpfc_sermon_attachments(); ?>
+				<?php endif; ?>
             </div>
 		<?php endif; ?>
     </div>


### PR DESCRIPTION
This patch adds a new option `archive_meta` which controls inclusion of `wpfc_sermon_attachments` function on the archive page in order to mimic the Sermon Browser feature below that we use to supply small group notes associated with a sermon: 
![image](https://user-images.githubusercontent.com/1498508/34699110-89099e0e-f4d3-11e7-8647-1956451f53df.png)
