### PR TITLE
add WP search to archive, limited to wpfc_sermon post type and AND match

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -879,7 +879,19 @@ class WPFC_Shortcodes {
 
 		if ( $query->have_posts() ) {
 			ob_start(); ?>
+
             <div id="wpfc_sermon">
+
+			<form role="search" method="get" class="wpfc_searchform" action="<?php echo home_url( '/' ); ?>">
+			<h4>Search</h4>
+				<div>
+					<input type="text" name="s" id="s" placeholder="Search by book, preacher, month & more.." />
+					<input type="hidden" name="sentence" value="1" />
+					<input type="hidden" name="post_type" value="wpfc_sermon" />
+					<button type="submit" id="searchsubmit" value="Search" class="btn btn-default"><i class="glyphicon glyphicon-search"></i></button>
+				</div>
+			</form>
+
                 <div id="wpfc_loading">
 					<?php while ( $query->have_posts() ): ?>
 						<?php $query->the_post();


### PR DESCRIPTION
This PR adds a WordPress search form to the archive page. 

Currently hard-coded are that it will return only WPFC sermons and applies 'sentence' search, in other words if you search Ruth and Eddie (one of our preachers) only matches of both will be returned. 

I did wonder if it should be an option to exclude the new search form but I think it is a useful addition to everyone and I see search is listed on your Trello board. This is not search like Sermon Browser used to do it but I do believe it is more in keeping with WP guidelines and don't anticipate users having a problem understanding it (time will tell!).

Finally by adding a CSS class to the form it can be pretty easily integrated into different themes. 

Hope you like it but if not please suggest changes.