### PR TITLE
Replace 'Continue Reading' link on archive page

### DIFF
--- a/includes/sm-template-functions.php
+++ b/includes/sm-template-functions.php
@@ -636,9 +636,9 @@ function wpfc_sermon_excerpt_v2( $return = false, $args = array() ) {
 			</div>
 			<?php $sermon_description = get_post_meta( $post->ID, 'sermon_description', true ); ?>
 			<div class="wpfc-sermon-description">
-                <?php echo wp_trim_words( $sermon_description, 30 ); ?><br />
-                <a href="<?php echo get_permalink(); ?>">Continue reading...</a>
-            </div>
+				<?php echo wp_trim_words( $sermon_description, 30 ); ?><br />
+				<a href="<?php echo get_permalink(); ?>">Continue reading...</a>
+			</div>
 			<?php if ( \SermonManager::getOption( 'archive_player' ) && get_wpfc_sermon_meta( 'sermon_audio' ) ) : ?>
 				<div class="wpfc-sermon-audio">
 					<?php echo wpfc_render_audio( get_wpfc_sermon_meta( 'sermon_audio' ), wpfc_get_media_url_seconds( get_wpfc_sermon_meta( 'sermon_audio' ) ) ); ?>

--- a/includes/sm-template-functions.php
+++ b/includes/sm-template-functions.php
@@ -637,7 +637,9 @@ function wpfc_sermon_excerpt_v2( $return = false, $args = array() ) {
 			<?php $sermon_description = get_post_meta( $post->ID, 'sermon_description', true ); ?>
 			<div class="wpfc-sermon-description">
 				<?php echo wp_trim_words( $sermon_description, 30 ); ?><br />
-				<a href="<?php echo get_permalink(); ?>">Continue reading...</a>
+				<div class="wpfc-sermon-description-read-more">
+					<a href="<?php echo get_permalink(); ?>"><?php echo __( 'Continue reading...', 'sermon-manager-for-wordpress' ); ?></a>
+				</div>
 			</div>
 			<?php if ( \SermonManager::getOption( 'archive_player' ) && get_wpfc_sermon_meta( 'sermon_audio' ) ) : ?>
 				<div class="wpfc-sermon-audio">

--- a/includes/sm-template-functions.php
+++ b/includes/sm-template-functions.php
@@ -635,7 +635,10 @@ function wpfc_sermon_excerpt_v2( $return = false, $args = array() ) {
 				<?php endif; ?>
 			</div>
 			<?php $sermon_description = get_post_meta( $post->ID, 'sermon_description', true ); ?>
-			<div class="wpfc-sermon-description"><?php echo wp_trim_words( $sermon_description, 30 ); ?></div>
+			<div class="wpfc-sermon-description">
+                <?php echo wp_trim_words( $sermon_description, 30 ); ?><br />
+                <a href="<?php echo get_permalink(); ?>">Continue reading...</a>
+            </div>
 			<?php if ( \SermonManager::getOption( 'archive_player' ) && get_wpfc_sermon_meta( 'sermon_audio' ) ) : ?>
 				<div class="wpfc-sermon-audio">
 					<?php echo wpfc_render_audio( get_wpfc_sermon_meta( 'sermon_audio' ), wpfc_get_media_url_seconds( get_wpfc_sermon_meta( 'sermon_audio' ) ) ); ?>


### PR DESCRIPTION
Replace the 'Continue reading' link below post snippet that's visible in the normal wordpress blog archive page