### PR TITLE
Sermon Excerpt Support

### DIFF
--- a/includes/admin/settings/class-sm-settings-debug.php
+++ b/includes/admin/settings/class-sm-settings-debug.php
@@ -72,7 +72,7 @@ class SM_Settings_Debug extends SM_Settings_Page {
 				'default' => 1,
 			),
 			array(
-				'title'   => '"post_excerpt" creation',
+				'title'   => 'Automatic "post_excerpt" creation',
 				'type'    => 'select',
 				'options' => array(
 					1  => 'Enable',

--- a/includes/class-sm-post-types.php
+++ b/includes/class-sm-post-types.php
@@ -261,7 +261,7 @@ class SM_Post_Types {
 				'comments',
 				'entry-views',
 				'elementor',
-				( !\SermonManager::getOption('post_excerpt_enabled', 1 ) ? 'excerpt' : null)
+				( ! \SermonManager::getOption( 'post_excerpt_enabled', 1 ) ? 'excerpt' : null ),
 			),
 		) ) );
 

--- a/includes/class-sm-post-types.php
+++ b/includes/class-sm-post-types.php
@@ -263,6 +263,7 @@ class SM_Post_Types {
 				'comments',
 				'entry-views',
 				'elementor',
+				( !\SermonManager::getOption('post_excerpt_enabled', 1 ) ? 'excerpt' : null)
 			),
 		) ) );
 

--- a/includes/class-sm-post-types.php
+++ b/includes/class-sm-post-types.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) or die;
 
+require_once SM_PATH . 'sermons.php';
+
 /**
  * Class made to replace old functions for registering post types and taxonomies.
  *
@@ -212,29 +214,29 @@ class SM_Post_Types {
 
 		register_post_type( 'wpfc_sermon', apply_filters( 'sm_register_post_type_wpfc_sermon', array(
 			'labels'              => array(
-				'name'                  => __( 'Sermons', 'sermon-manager-for-wordpress' ),
-				'singular_name'         => __( 'Sermon', 'sermon-manager-for-wordpress' ),
-				'all_items'             => __( 'Sermons', 'sermon-manager-for-wordpress' ),
-				'menu_name'             => _x( 'Sermons', 'menu', 'sermon-manager-for-wordpress' ),
-				'add_new'               => __( 'Add New', 'sermon-manager-for-wordpress' ),
-				'add_new_item'          => __( 'Add new sermon', 'sermon-manager-for-wordpress' ),
-				'edit'                  => __( 'Edit', 'sermon-manager-for-wordpress' ),
-				'edit_item'             => __( 'Edit sermon', 'sermon-manager-for-wordpress' ),
-				'new_item'              => __( 'New sermon', 'sermon-manager-for-wordpress' ),
-				'view'                  => __( 'View sermon', 'sermon-manager-for-wordpress' ),
-				'view_item'             => __( 'View sermon', 'sermon-manager-for-wordpress' ),
-				'search_items'          => __( 'Search sermon', 'sermon-manager-for-wordpress' ),
-				'not_found'             => __( 'No sermons found', 'sermon-manager-for-wordpress' ),
-				'not_found_in_trash'    => __( 'No sermons found in trash', 'sermon-manager-for-wordpress' ),
-				'featured_image'        => __( 'Sermon image', 'sermon-manager-for-wordpress' ),
-				'set_featured_image'    => __( 'Set sermon image', 'sermon-manager-for-wordpress' ),
-				'remove_featured_image' => __( 'Remove sermon image', 'sermon-manager-for-wordpress' ),
-				'use_featured_image'    => __( 'Use as sermon image', 'sermon-manager-for-wordpress' ),
-				'insert_into_item'      => __( 'Insert to sermon', 'sermon-manager-for-wordpress' ),
-				'uploaded_to_this_item' => __( 'Uploaded to this sermon', 'sermon-manager-for-wordpress' ),
-				'filter_items_list'     => __( 'Filter sermon', 'sermon-manager-for-wordpress' ),
-				'items_list_navigation' => __( 'Sermon navigation', 'sermon-manager-for-wordpress' ),
-				'items_list'            => __( 'Sermon list', 'sermon-manager-for-wordpress' ),
+				'name'                  => __( 'Sermons', SermonManager::PLUGIN_DOMAIN ),
+				'singular_name'         => __( 'Sermon', SermonManager::PLUGIN_DOMAIN ),
+				'all_items'             => __( 'Sermons', SermonManager::PLUGIN_DOMAIN ),
+				'menu_name'             => _x( 'Sermons', 'menu', SermonManager::PLUGIN_DOMAIN ),
+				'add_new'               => __( 'Add New', SermonManager::PLUGIN_DOMAIN ),
+				'add_new_item'          => __( 'Add new sermon', SermonManager::PLUGIN_DOMAIN ),
+				'edit'                  => __( 'Edit', SermonManager::PLUGIN_DOMAIN ),
+				'edit_item'             => __( 'Edit sermon', SermonManager::PLUGIN_DOMAIN ),
+				'new_item'              => __( 'New sermon', SermonManager::PLUGIN_DOMAIN ),
+				'view'                  => __( 'View sermon', SermonManager::PLUGIN_DOMAIN ),
+				'view_item'             => __( 'View sermon', SermonManager::PLUGIN_DOMAIN ),
+				'search_items'          => __( 'Search sermon', SermonManager::PLUGIN_DOMAIN ),
+				'not_found'             => __( 'No sermons found', SermonManager::PLUGIN_DOMAIN ),
+				'not_found_in_trash'    => __( 'No sermons found in trash', SermonManager::PLUGIN_DOMAIN ),
+				'featured_image'        => __( 'Sermon image', SermonManager::PLUGIN_DOMAIN ),
+				'set_featured_image'    => __( 'Set sermon image', SermonManager::PLUGIN_DOMAIN ),
+				'remove_featured_image' => __( 'Remove sermon image', SermonManager::PLUGIN_DOMAIN ),
+				'use_featured_image'    => __( 'Use as sermon image', SermonManager::PLUGIN_DOMAIN ),
+				'insert_into_item'      => __( 'Insert to sermon', SermonManager::PLUGIN_DOMAIN ),
+				'uploaded_to_this_item' => __( 'Uploaded to this sermon', SermonManager::PLUGIN_DOMAIN ),
+				'filter_items_list'     => __( 'Filter sermon', SermonManager::PLUGIN_DOMAIN ),
+				'items_list_navigation' => __( 'Sermon navigation', SermonManager::PLUGIN_DOMAIN ),
+				'items_list'            => __( 'Sermon list', SermonManager::PLUGIN_DOMAIN ),
 			),
 			'public'              => true,
 			'show_ui'             => true,

--- a/includes/class-sm-post-types.php
+++ b/includes/class-sm-post-types.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) or die;
 
-require_once SM_PATH . 'sermons.php';
-
 /**
  * Class made to replace old functions for registering post types and taxonomies.
  *
@@ -214,29 +212,29 @@ class SM_Post_Types {
 
 		register_post_type( 'wpfc_sermon', apply_filters( 'sm_register_post_type_wpfc_sermon', array(
 			'labels'              => array(
-				'name'                  => __( 'Sermons', SermonManager::PLUGIN_DOMAIN ),
-				'singular_name'         => __( 'Sermon', SermonManager::PLUGIN_DOMAIN ),
-				'all_items'             => __( 'Sermons', SermonManager::PLUGIN_DOMAIN ),
-				'menu_name'             => _x( 'Sermons', 'menu', SermonManager::PLUGIN_DOMAIN ),
-				'add_new'               => __( 'Add New', SermonManager::PLUGIN_DOMAIN ),
-				'add_new_item'          => __( 'Add new sermon', SermonManager::PLUGIN_DOMAIN ),
-				'edit'                  => __( 'Edit', SermonManager::PLUGIN_DOMAIN ),
-				'edit_item'             => __( 'Edit sermon', SermonManager::PLUGIN_DOMAIN ),
-				'new_item'              => __( 'New sermon', SermonManager::PLUGIN_DOMAIN ),
-				'view'                  => __( 'View sermon', SermonManager::PLUGIN_DOMAIN ),
-				'view_item'             => __( 'View sermon', SermonManager::PLUGIN_DOMAIN ),
-				'search_items'          => __( 'Search sermon', SermonManager::PLUGIN_DOMAIN ),
-				'not_found'             => __( 'No sermons found', SermonManager::PLUGIN_DOMAIN ),
-				'not_found_in_trash'    => __( 'No sermons found in trash', SermonManager::PLUGIN_DOMAIN ),
-				'featured_image'        => __( 'Sermon image', SermonManager::PLUGIN_DOMAIN ),
-				'set_featured_image'    => __( 'Set sermon image', SermonManager::PLUGIN_DOMAIN ),
-				'remove_featured_image' => __( 'Remove sermon image', SermonManager::PLUGIN_DOMAIN ),
-				'use_featured_image'    => __( 'Use as sermon image', SermonManager::PLUGIN_DOMAIN ),
-				'insert_into_item'      => __( 'Insert to sermon', SermonManager::PLUGIN_DOMAIN ),
-				'uploaded_to_this_item' => __( 'Uploaded to this sermon', SermonManager::PLUGIN_DOMAIN ),
-				'filter_items_list'     => __( 'Filter sermon', SermonManager::PLUGIN_DOMAIN ),
-				'items_list_navigation' => __( 'Sermon navigation', SermonManager::PLUGIN_DOMAIN ),
-				'items_list'            => __( 'Sermon list', SermonManager::PLUGIN_DOMAIN ),
+				'name'                  => __( 'Sermons', 'sermon-manager-for-wordpress' ),
+				'singular_name'         => __( 'Sermon', 'sermon-manager-for-wordpress' ),
+				'all_items'             => __( 'Sermons', 'sermon-manager-for-wordpress' ),
+				'menu_name'             => _x( 'Sermons', 'menu', 'sermon-manager-for-wordpress' ),
+				'add_new'               => __( 'Add New', 'sermon-manager-for-wordpress' ),
+				'add_new_item'          => __( 'Add new sermon', 'sermon-manager-for-wordpress' ),
+				'edit'                  => __( 'Edit', 'sermon-manager-for-wordpress' ),
+				'edit_item'             => __( 'Edit sermon', 'sermon-manager-for-wordpress' ),
+				'new_item'              => __( 'New sermon', 'sermon-manager-for-wordpress' ),
+				'view'                  => __( 'View sermon', 'sermon-manager-for-wordpress' ),
+				'view_item'             => __( 'View sermon', 'sermon-manager-for-wordpress' ),
+				'search_items'          => __( 'Search sermon', 'sermon-manager-for-wordpress' ),
+				'not_found'             => __( 'No sermons found', 'sermon-manager-for-wordpress' ),
+				'not_found_in_trash'    => __( 'No sermons found in trash', 'sermon-manager-for-wordpress' ),
+				'featured_image'        => __( 'Sermon image', 'sermon-manager-for-wordpress' ),
+				'set_featured_image'    => __( 'Set sermon image', 'sermon-manager-for-wordpress' ),
+				'remove_featured_image' => __( 'Remove sermon image', 'sermon-manager-for-wordpress' ),
+				'use_featured_image'    => __( 'Use as sermon image', 'sermon-manager-for-wordpress' ),
+				'insert_into_item'      => __( 'Insert to sermon', 'sermon-manager-for-wordpress' ),
+				'uploaded_to_this_item' => __( 'Uploaded to this sermon', 'sermon-manager-for-wordpress' ),
+				'filter_items_list'     => __( 'Filter sermon', 'sermon-manager-for-wordpress' ),
+				'items_list_navigation' => __( 'Sermon navigation', 'sermon-manager-for-wordpress' ),
+				'items_list'            => __( 'Sermon list', 'sermon-manager-for-wordpress' ),
 			),
 			'public'              => true,
 			'show_ui'             => true,

--- a/includes/sm-template-functions.php
+++ b/includes/sm-template-functions.php
@@ -634,13 +634,20 @@ function wpfc_sermon_excerpt_v2( $return = false, $args = array() ) {
 					</div>
 				<?php endif; ?>
 			</div>
-			<?php $sermon_description = get_post_meta( $post->ID, 'sermon_description', true ); ?>
 			<div class="wpfc-sermon-description">
-				<?php echo wp_trim_words( $sermon_description, 30 ); ?><br />
+				<div class="sermon-description-content">
+					<?php if ( strlen( get_the_excerpt( $post ) ) > 0 ) : ?>
+						<?php echo get_the_excerpt( $post ); ?>
+					<?php else: ?>
+						<?php echo wp_trim_words( get_post_meta( $post->ID, 'sermon_description', true ), 30 ); ?>
+					<?php endif; ?>
+					<br />
+				</div>
 				<div class="wpfc-sermon-description-read-more">
 					<a href="<?php echo get_permalink(); ?>"><?php echo __( 'Continue reading...', 'sermon-manager-for-wordpress' ); ?></a>
 				</div>
 			</div>
+
 			<?php if ( \SermonManager::getOption( 'archive_player' ) && get_wpfc_sermon_meta( 'sermon_audio' ) ) : ?>
 				<div class="wpfc-sermon-audio">
 					<?php echo wpfc_render_audio( get_wpfc_sermon_meta( 'sermon_audio' ), wpfc_get_media_url_seconds( get_wpfc_sermon_meta( 'sermon_audio' ) ) ); ?>

--- a/sermons.php
+++ b/sermons.php
@@ -442,31 +442,32 @@ class SermonManager {
 		$content = apply_filters( 'sm_sermon_post_content', $content, $post_ID, $post, $skip_check );
 		$content = apply_filters( "sm_sermon_post_content_$post_ID", $content, $post_ID, $post, $skip_check );
 
-		$excerpt = ! $content ? '' : wp_trim_excerpt( $content );
-
-		/**
-		 * Allows to modify sermon content that will be saved as "post_excerpt".
-		 *
-		 * @param string  $excerpt    Textual content (no HTML), limited to 55 words by default.
-		 * @param int     $post_ID    ID of the sermon.
-		 * @param WP_Post $post       Sermon post object.
-		 * @param bool    $skip_check Basically, a way to identify if the function is being executed from the update function or not.
-		 *
-		 * @since 2.11.0
-		 */
-		$excerpt = apply_filters( 'sm_sermon_post_excerpt', $excerpt, $post_ID, $post, $skip_check );
-		$excerpt = apply_filters( "sm_sermon_post_excerpt_$post_ID", $excerpt, $post_ID, $post, $skip_check );
-
 		if ( ! $skip_content_check ) {
 			if ( ! \SermonManager::getOption( 'post_content_enabled', 1 ) ) {
 				$content = '';
 			}
 		}
 
-		if ( ! $skip_excerpt_check ) {
-			if ( ! \SermonManager::getOption( 'post_excerpt_enabled', 1 ) ) {
-				$excerpt = '';
-			}
+		if ( \SermonManager::getOption( 'post_excerpt_enabled', 1 ) ) {
+			//Only generate our post excerpt if excerpt generation is turned on
+
+			$excerpt = ! $content ? '' : wp_trim_excerpt( $content );
+
+			/**
+			 * Allows to modify sermon content that will be saved as "post_excerpt".
+			 *
+			 * @param string  $excerpt    Textual content (no HTML), limited to 55 words by default.
+			 * @param int     $post_ID    ID of the sermon.
+			 * @param WP_Post $post       Sermon post object.
+			 * @param bool    $skip_check Basically, a way to identify if the function is being executed from the update function or not.
+			 *
+			 * @since 2.11.0
+			 */
+			$excerpt = apply_filters( 'sm_sermon_post_excerpt', $excerpt, $post_ID, $post, $skip_check );
+			$excerpt = apply_filters( "sm_sermon_post_excerpt_$post_ID", $excerpt, $post_ID, $post, $skip_check );
+		} else {
+			//Otherwise, go with whatever the user typed in...
+			$excerpt = $post->post_excerpt;
 		}
 
 		$wpdb->query( $wpdb->prepare( "UPDATE $wpdb->posts SET `post_content` = %s, `post_excerpt` = %s WHERE `ID` = %s", array(

--- a/sermons.php
+++ b/sermons.php
@@ -61,12 +61,17 @@ class SermonManager {
 	private static $instance = null;
 
 	/**
+	 * @var string The domain(sic) name to use when scoping variables and keywords (since WP hasn't heard of namespacing)
+	 */
+	const PLUGIN_DOMAIN = 'sermon-manager-for-wordpress';
+
+	/**
 	 * Construct.
 	 */
 	public function __construct() {
 		// Define constants (PATH and URL are with a trailing slash).
 		define( 'SM_PLUGIN_FILE', __FILE__ );
-		define( 'SM_PATH', dirname( SM_PLUGIN_FILE ) . '/' );
+		define( 'SM_PATH', dirname( SM_PLUGIN_FILE ) . DIRECTORY_SEPARATOR );
 		define( 'SM_BASENAME', plugin_basename( __FILE__ ) );
 		define( 'SM_URL', plugin_dir_url( __FILE__ ) );
 		define( 'SM_VERSION', preg_match( '/^.*Version: (.*)$/m', file_get_contents( __FILE__ ), $version ) ? trim( $version[1] ) : 'N/A' );

--- a/sermons.php
+++ b/sermons.php
@@ -61,17 +61,12 @@ class SermonManager {
 	private static $instance = null;
 
 	/**
-	 * @var string The domain(sic) name to use when scoping variables and keywords (since WP hasn't heard of namespacing)
-	 */
-	const PLUGIN_DOMAIN = 'sermon-manager-for-wordpress';
-
-	/**
 	 * Construct.
 	 */
 	public function __construct() {
 		// Define constants (PATH and URL are with a trailing slash).
 		define( 'SM_PLUGIN_FILE', __FILE__ );
-		define( 'SM_PATH', dirname( SM_PLUGIN_FILE ) . DIRECTORY_SEPARATOR );
+		define( 'SM_PATH', dirname( SM_PLUGIN_FILE ) . '/' );
 		define( 'SM_BASENAME', plugin_basename( __FILE__ ) );
 		define( 'SM_URL', plugin_dir_url( __FILE__ ) );
 		define( 'SM_VERSION', preg_match( '/^.*Version: (.*)$/m', file_get_contents( __FILE__ ), $version ) ? trim( $version[1] ) : 'N/A' );

--- a/sermons.php
+++ b/sermons.php
@@ -444,7 +444,7 @@ class SermonManager {
 		}
 
 		if ( \SermonManager::getOption( 'post_excerpt_enabled', 1 ) ) {
-			//Only generate our post excerpt if excerpt generation is turned on
+			// Only generate our post excerpt if excerpt generation is turned on
 
 			$excerpt = ! $content ? '' : wp_trim_excerpt( $content );
 
@@ -461,7 +461,7 @@ class SermonManager {
 			$excerpt = apply_filters( 'sm_sermon_post_excerpt', $excerpt, $post_ID, $post, $skip_check );
 			$excerpt = apply_filters( "sm_sermon_post_excerpt_$post_ID", $excerpt, $post_ID, $post, $skip_check );
 		} else {
-			//Otherwise, go with whatever the user typed in...
+			// Otherwise, go with whatever the user typed in...
 			$excerpt = $post->post_excerpt;
 		}
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (WPCS)
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.

<!--
========== ATTRIBUTION ==========
PR Template copied from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->

This modifies the behaviour (slightly) of the existing excerpt creation code. Users who have automatic excerpt creation turned on (default) will not notice this, however.

- Turning excerpt creation off causes the "Except" box to be available in the sermon editor (just like normal blog posts)
![image](https://user-images.githubusercontent.com/537684/39411569-9f93a68e-4bda-11e8-8fd8-05d61c8e38c2.png)
- Failure to set an excerpt(in other words, leaving the box blank) will cause a truncated version of `sermon_description` to be displayed. This is truncated to 30 words, as before.