### PR TITLE
Fix Archive Page

### DIFF
--- a/includes/sm-template-functions.php
+++ b/includes/sm-template-functions.php
@@ -636,7 +636,7 @@ function wpfc_sermon_excerpt_v2( $return = false, $args = array() ) {
 			</div>
 			<div class="wpfc-sermon-description">
 				<div class="sermon-description-content">
-					<?php if ( strlen( get_the_excerpt( $post ) ) > 0 ) : ?>
+					<?php if ( has_excerpt( $post ) ) : ?>
 						<?php echo get_the_excerpt( $post ); ?>
 					<?php else: ?>
 						<?php echo wp_trim_words( get_post_meta( $post->ID, 'sermon_description', true ), 30 ); ?>


### PR DESCRIPTION
The merging in of #196 caused the archive page to stop loading. This is due to the fact that I was using the wrong function to check to see if a post has an excerpt. This bug must have been introduced during a rebase.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (WPCS)
- [ ] My change requires a change to the documentation.
- [X] I have read the **CONTRIBUTING** document.

<!--
========== ATTRIBUTION ==========
PR Template copied from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->
