### PR TITLE
Add support for OceanWP theme and add support for copying wrapper to …

### DIFF
--- a/views/archive-wpfc_sermon.php
+++ b/views/archive-wpfc_sermon.php
@@ -7,7 +7,7 @@
 
 get_header(); ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 <?php
@@ -26,7 +26,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/partials/content-sermon-wrapper-end.php
+++ b/views/partials/content-sermon-wrapper-end.php
@@ -69,6 +69,12 @@ switch ( $template ) {
 	    get_sidebar();
 	    echo '</div></div>';
 	    break;
+    case 'oceanwp';
+        echo '</div><!-- end of #content -->';
+        echo '</div><!-- end of #primary -->';
+        get_sidebar();
+        echo '</div><!-- end of #content-wrap -->';
+        break;
 	default:
 		ob_start();
 		get_sidebar();

--- a/views/partials/content-sermon-wrapper-start.php
+++ b/views/partials/content-sermon-wrapper-start.php
@@ -49,6 +49,9 @@ switch ( $template ) {
 	case 'bb-theme-builder';
 	    echo '<div class="container"><div class="row"><div class="fl-content fl-content-left col-md-8">';
 	    break;
+    case 'oceanwp';
+        echo '<div id="content-wrap" class="container clr"><div id="primary" class="content-area clr"><div id="content" class="site-content clr">';
+        break;
 	default:
 		echo apply_filters( 'sm_templates_wrapper_start', '<div class="wrap"><div id="primary" class="content-area"><main id="main" class="site-main wpfc-sermon-container">' );
 		break;

--- a/views/single-wpfc_sermon.php
+++ b/views/single-wpfc_sermon.php
@@ -7,7 +7,7 @@
 
 get_header(); ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php
 while ( have_posts() ) :
@@ -26,7 +26,7 @@ while ( have_posts() ) :
 endwhile;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/taxonomy-wpfc_bible_book.php
+++ b/views/taxonomy-wpfc_bible_book.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 
@@ -28,7 +28,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/taxonomy-wpfc_preacher.php
+++ b/views/taxonomy-wpfc_preacher.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 
@@ -28,7 +28,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/taxonomy-wpfc_sermon_series.php
+++ b/views/taxonomy-wpfc_sermon_series.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 
@@ -28,7 +28,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/taxonomy-wpfc_sermon_topics.php
+++ b/views/taxonomy-wpfc_sermon_topics.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 
@@ -28,7 +28,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();

--- a/views/taxonomy-wpfc_service_type.php
+++ b/views/taxonomy-wpfc_service_type.php
@@ -8,7 +8,7 @@
 get_header();
 ?>
 
-<?php include 'partials/wrapper-start.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-start'); ?>
 
 <?php echo render_wpfc_sorting(); ?>
 
@@ -28,7 +28,7 @@ else :
 endif;
 ?>
 
-<?php include 'partials/wrapper-end.php'; ?>
+<?php echo wpfc_get_partial('content-sermon-wrapper-end'); ?>
 
 <?php
 get_footer();


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project. (WPCS)
- [ ] My change requires a change to the documentation.
- [x ] I have read the **CONTRIBUTING** document.

<!--
========== ATTRIBUTION ==========
PR Template copied from: https://github.com/h5bp/html5-boilerplate/blob/master/.github/PULL_REQUEST_TEMPLATE.md
-->

Changes:
* Added OceanWP theme template to wrapper-start and wrapper-end.
* Added support for copying wrapper-start and wrapper-end to child theme partials directory.
* Renamed wrapper-start to content-sermon-wrapper.start and wrapper-end to content-sermon-wrapper-end to maintain naming consistency if copied to child theme.
