### PR TITLE
use pipe separator instead of line breaks for visual consistency

### DIFF
--- a/sermons.php
+++ b/sermons.php
@@ -390,8 +390,7 @@ class SermonManager {
 		$description = strip_tags( trim( get_post_meta( $post->ID, 'sermon_description', true ) ) );
 
 		if ( '' !== $description ) {
-			$content .= PHP_EOL . PHP_EOL;
-			$content .= $description;
+			$content .= ' | ' . $description;
 		}
 
 		/**


### PR DESCRIPTION
Makes appearance of tags and description consistent when sharing on social networks, or anywhere else the post content is used.

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply (remove the space character first): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
This improves the appearance of Open Graph text when using the popular Yoast SEO plugin, or anywhere else that shows the `post_content` field with the line breaks stripped out.

![screen shot 2018-06-18 at 1 18 29 pm](https://user-images.githubusercontent.com/784333/41551546-29fa0d22-72fa-11e8-9c25-6cb52441d7d5.png)
![screen shot 2018-06-18 at 1 18 44 pm](https://user-images.githubusercontent.com/784333/41551547-2a0a01fa-72fa-11e8-8ac8-8f9a5910e9a2.png)
