### PR TITLE
Append service type title to Podcast feed when loading a service type

### DIFF
--- a/views/wpfc-podcast-feed.php
+++ b/views/wpfc-podcast-feed.php
@@ -106,9 +106,9 @@ if ( $taxonomy && $term ) {
 			'terms'    => $term,
 		),
 	);
-	if($taxonomy === 'wpfc_service_type') {
-		$settings['title'] = single_term_title($settings['title'].' - ', false);
-	}
+	
+	// Append term name to the feed title, so it looks like "Feed Name - Term Name".
+	$settings['title'] = single_term_title( $settings['title'] . ' - ', false );
 }
 
 /**

--- a/views/wpfc-podcast-feed.php
+++ b/views/wpfc-podcast-feed.php
@@ -106,6 +106,9 @@ if ( $taxonomy && $term ) {
 			'terms'    => $term,
 		),
 	);
+	if($taxonomy === 'wpfc_service_type') {
+		$settings['title'] = single_term_title($settings['title'].' - ', false);
+	}
 }
 
 /**


### PR DESCRIPTION
## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply (remove the space character first): -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
Our church submits separate Podcast feeds to iTunes for each service type. It's helpful to have the name of the Service Type in the feed's title so it appears when people search for us in their Podcast players.

My code adds on to the taxonomy conditional in `wpfc-podcast-feed.php` and appends the service type title if the taxonomy is `wpfc_service_type`. I'm not sure if it follows WPCS standards but I tried to make it as non-invasive as possible.

I have this change running on our servers already, here are the feeds to verify:

https://www.gracegathering.com/service-type/new-haven/feed/
https://www.gracegathering.com/service-type/north/feed/

And our default feed to show it's unaffected by the change:

https://www.gracegathering.com/feed/?post_type=wpfc_sermon

Thanks for all your hard work on this plugin! Let me know if this is a type of pull request you'd be willing to accept, and if so, if the code I added follows the projects conventions.