### PR TITLE
Add french bible versions for verses

### DIFF
--- a/includes/admin/settings/class-sm-settings-verse.php
+++ b/includes/admin/settings/class-sm-settings-verse.php
@@ -107,6 +107,7 @@ class SM_Settings_Verse extends SM_Settings_Page {
 				'desc'    => __( 'Default: ESV.', 'sermon-manager-for-wordpress' ),
 				'id'      => 'verse_bible_version',
 				'options' => array(
+					// English versions.
 					'AMP'         => 'Amplified Bible (AMP)',
 					'ASV'         => 'American Standard Version (ASV)',
 					'DAR'         => 'Darby',
@@ -124,6 +125,10 @@ class SM_Settings_Verse extends SM_Settings_Page {
 					'NLT'         => 'New Living Translation (NLT)',
 					'DOUAYRHEIMS' => 'Douay-Rheims',
 					'YLT'         => 'Young\'s Literal Translation (YLT)',
+
+					// French versions.
+					'LSG'         		=> 'La Bible Louis Second 1910',
+					'EC-SBGBIBS212007' 	=> 'La Bible Second 21'
 				),
 				'default' => 'ESV',
 			),


### PR DESCRIPTION
## Types of changes:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
Hi, I added Bible versions for my native language.

## Any other info:
I do not know if it's a choice to only have english versions, without possibility to select more versions among the list of possible ones on https://biblia.com, so I only added ones for French. 

I did not find the code responsible for parsing verse abbreviations, but if you merge this PR and say to me how to do it, I would like to add french abbreviation parsing.

Regards.
