### PR TITLE
Fixed issue 271 sermon_video_embed missing on api

### DIFF
--- a/includes/admin/export/class-sm-export-sm.php
+++ b/includes/admin/export/class-sm-export-sm.php
@@ -399,7 +399,7 @@ class SM_Export_SM {
 					$meta_value_array = array();
 					$meta_key_name    = array(
 						'sermon_audio',
-						'sermon_video',
+						'sermon_video_emebed',
 						'sermon_video_link',
 						'sermon_notes',
 						'sermon_bulletin',

--- a/includes/admin/import/class-sm-import-sb.php
+++ b/includes/admin/import/class-sm-import-sb.php
@@ -501,7 +501,7 @@ class SM_Import_SB {
 				} elseif ( 'code' === $item->type ) {
 					$this->log( 'Found video embed!', 253 );
 
-					update_post_meta( $id, 'sermon_video', base64_decode( $item->name ) );
+					update_post_meta( $id, 'sermon_video_embed', base64_decode( $item->name ) );
 				}
 			}
 

--- a/includes/admin/import/class-sm-import-se.php
+++ b/includes/admin/import/class-sm-import-se.php
@@ -423,7 +423,7 @@ class SM_Import_SE {
 
 			// Set video embed.
 			if ( ! empty( $message->embed_code ) ) {
-				update_post_meta( $id, 'sermon_video', $message->embed_code );
+				update_post_meta( $id, 'sermon_video_embed', $message->embed_code );
 			}
 
 			// Set views.

--- a/includes/admin/sm-cmb-functions.php
+++ b/includes/admin/sm-cmb-functions.php
@@ -109,7 +109,7 @@ function wpfc_sermon_metaboxes() {
 	$sermon_files_meta->add_field( array(
 		'name' => esc_html__( 'Video Embed Code', 'sermon-manager-for-wordpress' ),
 		'desc' => esc_html__( 'Paste your embed code for Vimeo, Youtube, Facebook, or direct video file here', 'sermon-manager-for-wordpress' ),
-		'id'   => 'sermon_video',
+		'id'   => 'sermon_video_embed',
 		'type' => 'textarea_code',
 	) );
 	$sermon_files_meta->add_field( apply_filters( 'sm_cmb2_field_sermon_video_link', array(

--- a/includes/class-sm-api.php
+++ b/includes/class-sm-api.php
@@ -133,7 +133,7 @@ class SM_API {
 			'Views'                 => array( '' ),
 			'bible_passage'         => array( '' ),
 			'sermon_description'    => array( '' ),
-			'sermon_video'          => array( '' ),
+			'sermon_video_embed'    => array( '' ),
 			'sermon_video_link'     => array( '' ),
 			'sermon_bulletin'       => array( '' ),
 			'_thumbnail_id'         => array( '' ),
@@ -149,7 +149,7 @@ class SM_API {
 		$data['_views']                = $post_meta['Views'][0];
 		$data['bible_passage']         = $post_meta['bible_passage'][0];
 		$data['sermon_description']    = $post_meta['sermon_description'][0];
-		$data['sermon_video_embed']    = $post_meta['sermon_video'][0];
+		$data['sermon_video_embed']    = $post_meta['sermon_video_embed'][0];
 		$data['sermon_video_url']      = $post_meta['sermon_video_link'][0];
 		$data['sermon_bulletin']       = $post_meta['sermon_bulletin'][0];
 		$data['_featured_url']         = wp_get_attachment_url( $post_meta['_thumbnail_id'][0] );

--- a/includes/sm-deprecated-functions.php
+++ b/includes/sm-deprecated-functions.php
@@ -358,7 +358,7 @@ function wpfc_sermon_media() {
 		$html .= '</div>';
 	} else {
 		$html .= '<div class="wpfc_sermon-video cf">';
-		$html .= do_shortcode( get_wpfc_sermon_meta( 'sermon_video' ) );
+		$html .= do_shortcode( get_wpfc_sermon_meta( 'sermon_video_embed' ) );
 		$html .= '</div>';
 	}
 

--- a/views/partials/content-sermon-single.php
+++ b/views/partials/content-sermon-single.php
@@ -77,9 +77,9 @@ global $post;
 						<?php echo wpfc_render_video( get_wpfc_sermon_meta( 'sermon_video_link' ) ); ?>
 					</div>
 				<?php endif; ?>
-				<?php if ( get_wpfc_sermon_meta( 'sermon_video' ) ) : ?>
+				<?php if ( get_wpfc_sermon_meta( 'sermon_video_embed' ) ) : ?>
 					<div class="wpfc-sermon-single-video wpfc-sermon-single-video-embed">
-						<?php echo do_shortcode( get_wpfc_sermon_meta( 'sermon_video' ) ); ?>
+						<?php echo do_shortcode( get_wpfc_sermon_meta( 'sermon_video_embed' ) ); ?>
 					</div>
 				<?php endif; ?>
 


### PR DESCRIPTION
## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply (remove the space character first): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
<!--- What does your change do? What does it fix or change? -->
refactored sermon_video to sermon_video_embed throughout the code base



## Any other info:
<!-- Such as: possible pitfalls, required changes on update, unfinished features, etc... -->


