### PR TITLE
Fix Shortcode Pagination on Static Front Page

### DIFF
--- a/includes/class-sm-shortcodes.php
+++ b/includes/class-sm-shortcodes.php
@@ -848,7 +848,7 @@ class SM_Shortcodes {
 			'post_type'      => 'wpfc_sermon',
 			'posts_per_page' => $args['per_page'],
 			'order'          => $args['order'],
-			'paged'          => get_query_var( 'paged' ),
+			'paged'          => get_query_var( 'paged' ) ?: (get_query_var( 'page' ) ?: 1),
 		);
 
 		// Check if it's a valid ordering argument.
@@ -1156,7 +1156,7 @@ class SM_Shortcodes {
 									'current'  => $query->get( 'paged' ),
 									'total'    => $query->max_num_pages,
 									'end_size' => 3,
-									'add_args' => $add_args,
+									'add_args' => !is_front_page() ? $add_args : array(),
 								) );
 								?>
 							</div>


### PR DESCRIPTION
## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply (remove the space character first): -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [X] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
<!--- What does your change do? What does it fix or change? -->
It appears that between https://github.com/WP-for-Church/Sermon-Manager/commit/94e8f826387a5ae134e29b78b9fb3797b4e500e4 and https://github.com/WP-for-Church/Sermon-Manager/commit/ecfdbb7b772aa6801cbb1394dfd77ebc904a4854, PR #46 was reverted and static front page pagination was once again broken. This PR remedies this bug. Further, it seems like if you are on the first page, and the query parameter is empty, the Next button doesn't appear, so this will also default the value to 1 if neither `paged` nor `page` is defined.

Additionally, on static front pages, adding query strings to the end of the URL (https://yoursite.com/page/2/?page_id=873&p=873) will break the pagination functionality. It appears that these arguments are added by default on static front pages, most likely because the static front page suppresses the page information.  In this PR, I check `is_front_page()` before adding the query strings to `add_args` in `paginate_links()`. This regression was added in https://github.com/WP-for-Church/Sermon-Manager/commit/92fb1e963056e7fa39a01ce19f4ee782f1aefc99. 

## Any other info:
<!-- Such as: possible pitfalls, required changes on update, unfinished features, etc... -->

I'm not sure why the main sermons page utilizes the standard Wordpress DOM for pagination but the shortcode does not. It requires dual-styling. This is outside of the scope of this PR, so it's something that might be discussed in the future.
