### PR TITLE
Update broken Contributing link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@
 ## Checklist:
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
-- [ ] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
+- [ ] I have read the [**CONTRIBUTING**](./CONTRIBUTING.md) document.
 - [ ] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
 - [ ] My change requires a change to the documentation.
 

--- a/readme.txt
+++ b/readme.txt
@@ -83,7 +83,7 @@ When you upgrade to Pro you also get premium ticket and live chat support for th
 
 Would you like to help improve Sermon Manager or report a bug you found? This project is open source on [GitHub](https://github.com/WP-for-Church/Sermon-Manager)!
 
-(Note: Please read [contributing instructions](https://github.com/WP-for-Church/Sermon-Manager/blob/dev/CONTRIBUTING.md) first.)
+(Note: Please read [contributing instructions](https://github.com/WP-for-Church/Sermon-Manager/blob/dev/.github/CONTRIBUTING.md) first.)
 
 ### WP for Church ###
 


### PR DESCRIPTION
The current link is broken when file structure was fixed to the new github version.

## Types of changes:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply (remove the space character first): -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] My code follows the code style of this project. ([WPCS](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards))
- [ ] My change requires a change to the documentation.

## Brief description of the proposed change:
<!--- What does your change do? What does it fix or change? -->

The current link is broken when file structure was fixed to the new github version i.e. moving contributions.md to .github folder.
